### PR TITLE
Remove references to http-parser

### DIFF
--- a/Sanity/simple-tang-server-start/Makefile
+++ b/Sanity/simple-tang-server-start/Makefile
@@ -53,7 +53,7 @@ $(METADATA): Makefile
 	@echo "Type:            Sanity" >> $(METADATA)
 	@echo "TestTime:        24h" >> $(METADATA)
 	@echo "RunFor:          tang" >> $(METADATA)
-	@echo "Requires:        tang http-parser curl" >> $(METADATA)
+	@echo "Requires:        tang curl" >> $(METADATA)
 	@echo "Priority:        Normal" >> $(METADATA)
 	@echo "License:         GPLv2+" >> $(METADATA)
 	@echo "Confidential:    no" >> $(METADATA)

--- a/Sanity/simple-tang-server-start/main.fmf
+++ b/Sanity/simple-tang-server-start/main.fmf
@@ -5,7 +5,6 @@ component+:
 test: ./runtest.sh
 recommend:
   - tang
-  - http-parser
   - curl
 duration: 24h
 enabled: true

--- a/Sanity/simple-tang-server-start/runtest.sh
+++ b/Sanity/simple-tang-server-start/runtest.sh
@@ -30,7 +30,7 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 PACKAGE="tang"
-PACKAGES="${PACKAGE} http-parser curl"
+PACKAGES="${PACKAGE} curl"
 TANG="tangd.socket"
 
 rlJournalStart


### PR DESCRIPTION
We should rely on tang installing required dependencies