### PR TITLE
Add tang files ownership scenario

### DIFF
--- a/Sanity/tang-files-ownership/main.fmf
+++ b/Sanity/tang-files-ownership/main.fmf
@@ -1,0 +1,21 @@
+summary: verify correct file ownership
+description: verifies if important tang files have correct ownership
+contact: Patrik Koncity <pkoncity@redhat.com>
+component:
+- tang
+test: ./runtest.sh
+framework: beakerlib
+recommend:
+- tang
+- http-parser
+- jose
+duration: 5m
+enabled: true
+tag:
+- CI-Tier-1
+- Tier1
+tier: '1'
+adjust:
+-   enabled: false
+    when: distro == rhel-4, rhel-5, rhel-6, rhel-7, rhel-8
+    continue: false

--- a/Sanity/tang-files-ownership/runtest.sh
+++ b/Sanity/tang-files-ownership/runtest.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# vim: dict=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Author: Patrik Koncity <pkoncityt@redhat.com>
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+#   Copyright (c) 2025 Red Hat, Inc.
+#
+#   This copyrighted material is made available to anyone wishing
+#   to use, modify, copy, or redistribute it subject to the terms
+#   and conditions of the GNU General Public License version 2.
+#
+#   This program is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied
+#   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#   PURPOSE. See the GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public
+#   License along with this program; if not, write to the Free
+#   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+#   Boston, MA 02110-1301, USA.
+#
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+TESTDIR=`pwd`
+
+function checkFile() {
+    MUSTEXIST=false
+    if [ "$1" == "-e" ]; then
+        MUSTEXIST=true
+        shift
+    fi
+    FILEPATH=$1
+    OWNER=$2
+    GROUP=$3
+    if "$MUSTEXIST" || [ -e "$FILEPATH" ]; then
+        ls -ld $FILEPATH
+        rlRun "ls -ld $FILEPATH | grep -qE '$OWNER[ ]*$GROUP'"
+    fi
+}
+
+rlJournalStart
+    rlPhaseStartTest
+        rlServiceStart tangd.socket
+        rlRun "systemctl status tangd.socket" 0 "Confirm that tangd is running"
+        # verify user account
+        rlRun -s "id tang"
+        rlRun "grep -E 'groups=.*tang' $rlRun_LOG"
+        rlRun "grep -E 'gid=.*tang' $rlRun_LOG"
+        rlRun "grep -E 'uid=.*tang' $rlRun_LOG"
+        # check /var files
+        checkFile -e /var/db/tang tang tang
+        # check random /usr file
+        checkFile /usr/lib/sysusers.d/tang.conf root root
+	    rlServiceStop tangd.socket
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd


### PR DESCRIPTION
Check if tang files get right ownership.

## Summary by Sourcery

Add a sanity test to start tangd, confirm the tang user exists, and check that critical tang files have the correct ownership

New Features:
- Add a new sanity test scenario to verify tang files ownership

Tests:
- Introduce a Beakerlib-based script that starts tangd.socket, checks the tang user account, and validates ownership of /var/db/tang and /usr/lib/sysusers.d/tang.conf