### PR TITLE
Add missing tmt-IDs and reformat fmf files

### DIFF
--- a/Sanity/sha256-thp/main.fmf
+++ b/Sanity/sha256-thp/main.fmf
@@ -2,26 +2,27 @@ summary: Test tang SHA-256 thumbprints
 description: ''
 contact: Martin Zelený <mzeleny@redhat.com>
 component:
-- tang
+  - tang
 test: ./runtest.sh
 recommend:
-- tang
+  - tang
 duration: 10m
 enabled: true
 tag:
-- CI-Tier-1
-- Tier2
-- ImageMode
+  - CI-Tier-1
+  - Tier2
+  - ImageMode
 tier: '2'
 link:
--   verifies: https://bugzilla.redhat.com/show_bug.cgi?id=1956765
+  - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=1956765
 adjust:
--   enabled: false
+  - enabled: false
     when: distro < rhel-9
     continue: false
--   enabled: false
+  - enabled: false
     when: distro == rhel-alt-7
     continue: false
 extra-nitrate: TC#0610479
 extra-summary: /CoreOS/tang/Sanity/sha256-thp
 extra-task: /CoreOS/tang/Sanity/sha256-thp
+id: c531a97c-c7b2-41ca-82a7-e20d5de9f42a

--- a/Sanity/simple-tang-server-start-default-port/main.fmf
+++ b/Sanity/simple-tang-server-start-default-port/main.fmf
@@ -1,5 +1,5 @@
-summary: Run tang server, which stays running after test finishes. For manual testing
-    with --reserve parameter.
+summary: Run tang server, which stays running after test finishes. For manual 
+    testing with --reserve parameter.
 component+:
   - clevis
 test: ./runtest.sh
@@ -22,3 +22,4 @@ adjust:
   - enabled: false
     when: distro < rhel-7
     continue: false
+id: 4b6f2001-fc36-4660-b696-0dee81f7c5b8

--- a/Sanity/simple-tang-server-start-different-port/main.fmf
+++ b/Sanity/simple-tang-server-start-different-port/main.fmf
@@ -1,5 +1,5 @@
-summary: Run tang server on different port, which stays running after test finishes.
-    For manual testing with --reserve parameter.
+summary: Run tang server on different port, which stays running after test 
+    finishes. For manual testing with --reserve parameter.
 description: ''
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
@@ -19,3 +19,4 @@ adjust:
     when: distro < rhel-7
     continue: false
 extra-nitrate: TC#0612871
+id: 46b8f94c-56bc-4cc1-949e-950d81220172

--- a/Sanity/tang-files-ownership/main.fmf
+++ b/Sanity/tang-files-ownership/main.fmf
@@ -2,20 +2,21 @@ summary: verify correct file ownership
 description: verifies if important tang files have correct ownership
 contact: Patrik Koncity <pkoncity@redhat.com>
 component:
-- tang
+  - tang
 test: ./runtest.sh
 framework: beakerlib
 recommend:
-- tang
-- http-parser
-- jose
+  - tang
+  - http-parser
+  - jose
 duration: 5m
 enabled: true
 tag:
-- CI-Tier-1
-- Tier1
+  - CI-Tier-1
+  - Tier1
 tier: '1'
 adjust:
--   enabled: false
+  - enabled: false
     when: distro == rhel-4, rhel-5, rhel-6, rhel-7, rhel-8
     continue: false
+id: dd0d6615-f2a9-43c3-97a6-a202711d81c1


### PR DESCRIPTION
## Summary by Sourcery

Ensure all sanity test FMF files include tmt-IDs and adhere to a consistent formatting style

Enhancements:
- Add missing tmt-IDs to FMF metadata for sanity tests
- Reformat FMF files to ensure consistent formatting across test suites