### PR TITLE
Add fips tag to FIPS-relevant tests

### DIFF
--- a/Sanity/sha256-thp/main.fmf
+++ b/Sanity/sha256-thp/main.fmf
@@ -9,6 +9,7 @@ recommend:
 duration: 10m
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - Tier2
   - ImageMode

--- a/Sanity/simple-tang-server-start-default-port/main.fmf
+++ b/Sanity/simple-tang-server-start-default-port/main.fmf
@@ -9,6 +9,7 @@ recommend:
 duration: 24h
 enabled: true
 tag:
+  - fips
   - CI-Tier-1
   - NoRHEL4
   - NoRHEL5

--- a/Sanity/simple-tang-server-start-different-port/main.fmf
+++ b/Sanity/simple-tang-server-start-different-port/main.fmf
@@ -10,6 +10,7 @@ require+:
 duration: 5m
 enabled: true
 tag:
+  - fips
   - NoRHEL4
   - NoRHEL5
 extra-summary: /CoreOS/tang/Sanity/simple-tang-server-start-different-port


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update sanity test metadata to mark SHA-256 THP and tang server startup tests as FIPS-relevant.